### PR TITLE
Specify GitHub in the manifest

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -4,7 +4,7 @@
     "description": "Insert GIFs from Giphy.com into GitHub comments",
     "manifest_version": 2,
     "content_scripts": [{
-        "matches": ["*://*/*"],
+        "matches": ["https://github.com/*"],
         "js": ["inject.js"],
         "run_at": "document_idle"
     }],
@@ -13,6 +13,7 @@
         "extension.css"
     ],
     "permissions": [
+        "https://github.com/*",
         "https://api.giphy.com/v1/*"
     ],
     "background": {


### PR DESCRIPTION
This doesn't change the behavior of the extension, but makes sure that the extension only gets loaded into GitHub pages. You could probably `messageIfFound()` function in the inject.js file since this ensures it's only a Github page, but I didn't go that far.
