### PR TITLE
Make GifHub play nice with Refined GitHub

### DIFF
--- a/src/btn-template.html
+++ b/src/btn-template.html
@@ -1,4 +1,6 @@
 <button type="button" class="js-giphy-btn js-toolbar-item toolbar-item tooltipped tooltipped-nw"
     aria-label="Add a GIF" tabindex="-1" data-ga-click="Giphy">
-        <span class="giphy-btn"></span>
+        <svg aria-hidden="true" class="octicon octicon-file-media" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16">
+          <path d="M6 5h2v2H6V5z m6-0.5v9.5c0 0.55-0.45 1-1 1H1c-0.55 0-1-0.45-1-1V2c0-0.55 0.45-1 1-1h7.5l3.5 3.5z m-1 0.5L8 2H1v11l3-5 2 4 2-2 3 3V5z" />
+        </svg>
 </button>

--- a/src/styles/extension.css
+++ b/src/styles/extension.css
@@ -1,8 +1,3 @@
-.giphy-btn {
-    content: url('data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjE2IiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTYgNWgydjJINlY1eiBtNi0wLjV2OS41YzAgMC41NS0wLjQ1IDEtMSAxSDFjLTAuNTUgMC0xLTAuNDUtMS0xVjJjMC0wLjU1IDAuNDUtMSAxLTFoNy41bDMuNSAzLjV6IG0tMSAwLjVMOCAySDF2MTFsMy01IDIgNCAyLTIgMyAzVjV6IiAvPgo8L3N2Zz4K');
-    color: #767676;
-}
-
 .giphy-widget {
     display: inline-block;
     width: 280px;
@@ -88,4 +83,9 @@
 
 .giphy-widget li:nth-child(odd) {
     margin-right: 2%;
+}
+
+/* Styles to override Refined GitHub and play nicely */
+.toolbar-group .toolbar-item.js-giphy-btn {
+    display: block;
 }


### PR DESCRIPTION
This fixes #6.

The solution is pretty simple: I add a class to the toolbar and then override the CSS from the [Refined GitHub](https://github.com/sindresorhus/refined-github) extension so that only the GifHub button is shown. This shouldn't break the current version for anyone, nor "break" anything for the Refined GitHub users either.

![gifhub-in-refined-github](https://cloud.githubusercontent.com/assets/737065/14081054/a4ca4ad4-f4d6-11e5-9468-a21e655aeb7a.png)
