### PR TITLE
Add btn when editing new inline comments - fix #12

### DIFF
--- a/src/js/sites/GitHub/index.js
+++ b/src/js/sites/GitHub/index.js
@@ -1,6 +1,7 @@
 import {
     addBtnToToolbars,
     onPartialRender,
+    addBtnToNewInlineComments,
     onGiphyBtnClick,
     insertTextAtCursor
 } from './page';
@@ -17,6 +18,7 @@ window.$ = window.require('jquery');
 
 addBtnToToolbars();
 onPartialRender(addBtnToToolbars);
+addBtnToNewInlineComments();
 
 onGiphyBtnClick(({ form, button, input }) => {
     const onSelection = function onSelection(data) {

--- a/src/js/sites/GitHub/page.js
+++ b/src/js/sites/GitHub/page.js
@@ -11,6 +11,17 @@ export function onPartialRender(cb) {
     $(document).on('pjax:success', cb);
 }
 
+// adds giphy button when editing new inline comments
+export function addBtnToNewInlineComments() {
+    $(document).on('click', '.js-inline-comments-container .comment.previewable-edit .js-comment-edit-button', e => {
+        const addedComment = $(e.target).closest('.comment.previewable-edit').find('.toolbar-group:last-child');
+        if (addedComment.find('.js-giphy-btn').length > 0) {
+            return;
+        }
+        addedComment.append(btnTemplate);
+    });
+}
+
 export function onGiphyBtnClick(cb) {
     $(document).on('click', '.js-giphy-btn', ({ currentTarget: el }) => (
         cb({


### PR DESCRIPTION
This adds the button when editing new inline comments (like in a PR) that are generated without a page refresh.

To replicate, go to a PR and make a line comment, then attempt to edit that new line comment before refreshing the page. In `master` you should not see the GifHub button, in this PR you should see that button, and it should not add it more than once (if you edit and leave and edit again).
